### PR TITLE
handlebars version change to to 4.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "boom": "^7.1.1",
-        "handlebars": "^4.0.11",
+        "handlebars": "^4.1.2",
         "hoek": "^6.1.2",
         "http-status": "^1.0.1",
         "joi": "^13.1.2",


### PR DESCRIPTION
**yarn audit** is failing because of handlebars 
```
yarn audit v1.12.3
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ handlebars                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.14 <4.1.0 || >=4.1.2                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ hapi-swagger                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ hapi-swagger > handlebars                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/755                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```